### PR TITLE
Change the way isClip is checked

### DIFF
--- a/ios/ReactNativeAppClipModule.swift
+++ b/ios/ReactNativeAppClipModule.swift
@@ -74,9 +74,12 @@ public class ReactNativeAppClipModule: Module {
             }
         }.runOnQueue(DispatchQueue.main)
         
-        Function("getBundleIdentifier") { () -> String? in
-            let bundleIdentifier = Bundle.main.bundleIdentifier
-            return bundleIdentifier
+        Function("getBundleIdentifier") { () -> Bool? in
+            #if APPCLIP 
+            return true
+            #else
+            return false
+            #endif
         }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 import ReactNativeAppClipModule from "./ReactNativeAppClipModule";
 
 export function isClip(): boolean {
-  const bundleIdentifier = ReactNativeAppClipModule.getBundleIdentifier() as
-    | string
-    | undefined;
-  const isClip =
-    bundleIdentifier?.slice(bundleIdentifier.lastIndexOf(".") + 1) === "Clip";
-  return isClip;
+  return ReactNativeAppClipModule.getIsClip as boolean;
 }
 
 export function getContainerURL(groupIdentifier: string): string {


### PR DESCRIPTION
Instead of using the bundle identifier, use a conditional compiler flag for the Clip project.

TODO: Add in conditional compiler flag when adding the Clip project